### PR TITLE
Add navigation section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # info
+
+## Navigation
+
+- [Banlist](banlist/banlist.md)
+- Rules
+  - [General Rulebook](rules/general/general_rulebook.md)
+  - [In-Game Rules](rules/general/in_game_rules.md)
+  - [Roster Rules](rules/general/roster_rules.md)
+- Tournaments
+  - [Female Pro League #1 (2025)](tournaments/2025/Female%20Pro%20League%20%231.md)


### PR DESCRIPTION
## Summary
- add a navigation section to the README that links to key documents for the banlist, rules, and tournaments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfc1e0e9208322971bf17028ecf8b3