### PR TITLE
Restore Russian banlist text alongside English translation

### DIFF
--- a/banlist/banlist.md
+++ b/banlist/banlist.md
@@ -1,5 +1,100 @@
 # MySkill Banlist (Active)
 
+> This document consolidates the active bans recognized by MySkill across trusted publishers, tournament platforms, and anti-cheat providers. The English text below reflects the original Russian entries in the same order. The original Russian-language content is retained after the English version for reference.
+
+## Eligibility Policy
+MySkill reserves the right to refuse participation to players who hold active bans from the game publisher or other esports organizations, tournament operators, and anti-cheat systems that MySkill deems authoritative. If a tournament participant has received (or receives) a ban from the publisher’s anti-cheat system (Valve Anti-Cheat) or any other anti-cheat system used on the tournament platform (including FaceIT AC, GameGuard, Akros), they are subject to retroactive disqualification starting from their first match.
+
+---
+
+## Decision on the CCT Case (2025‑10‑02)
+[Source](https://www.hltv.org/news/42833/cct-issues-bans-to-three-teams-for-cheating)
+
+### Two-Year Disqualification (until 2027‑10‑02)
+- **Daniil “tEO” Prok (RU)** — Cheating — sources: CCT / Akros — [HLTV](https://www.hltv.org/player/22429/teo)
+- **Dastan “dosikk” Mauessov (KZ)** — Cheating — sources: CCT / Akros — [HLTV](https://www.hltv.org/player/24649/dosikk)
+- **Mark “d0RREN” Karachevtsev (RU)** — Cheating — sources: CCT / Akros — [HLTV](https://www.hltv.org/player/23987/d0rren)
+- **Idris “1Drezz” Beksultanov (KZ)** — Cheating — sources: CCT / Akros — [HLTV](https://www.hltv.org/player/24907/1drezz)
+- **Nurmukhammed “singulier” Mugal (KZ)** — Cheating — sources: CCT / Akros — [HLTV](https://www.hltv.org/player/24202/singulier)
+- **Zhanibek “R3LiFwOw” Kuatov (KZ)** — Cheating — sources: CCT / Akros — [HLTV](https://www.hltv.org/player/23665/r3lifwow)
+- **Raiymbek “dune” Dusenov (KZ)** — Account Sharing — source: CCT / Akros — [HLTV](https://www.hltv.org/player/24906/dune)
+
+### Six-Month Disqualification (until 2026‑04‑02)
+- **ElayDzha (KZ)** — [HLTV](https://www.hltv.org/player/24501/elaydzha)
+- **rinn (KZ)** — [HLTV](https://www.hltv.org/player/23318/rinn)
+- **OxygeN (KZ)** — [HLTV](https://www.hltv.org/player/23316/oxygen)
+- **for2na (KZ)** — [HLTV](https://www.hltv.org/player/23539/for2na)
+- **ddoni (KZ)** — [HLTV](https://www.hltv.org/player/24646/ddoni)
+- **tsukumeow (KZ)** — [HLTV](https://www.hltv.org/player/24650/tsukumeow)
+- **krc (KR)** — [HLTV](https://www.hltv.org/player/23990/krc)
+
+---
+
+## Other Active Platform Bans
+
+### AKROS Anti-Cheat
+> In addition to the priority six players (see above)
+
+| Player | Country | Team | Reason | Start | End | Source |
+|---|---:|---|---|---:|---:|---|
+| **Floki** | BR | 20/70 | Cheating | 2025‑01‑16 | Permanent | Akros |
+| **joel** | SE | bc.game esports | Cheating | 2024‑08‑04 | Permanent | Akros |
+
+
+### FASTCUP
+
+| Players | Country | Team | Reason | Start | End | Source |
+|---|---:|---|---|---:|---:|---|
+| rabbit, Yamero, Brens, m1kketye, Krip | LV / LV / LV / LV / LV | hypewrld | Cheating | 2024‑09‑05 | 2029‑09‑06 | FASTCUP |
+| 1nspireR, diray, sunshine, DamianTime, whydopplfall | LV / RU / LV / RU / RU | sleepwalkers (Russian team) | Cheating | 2024‑09‑04 | 2029‑09‑05 | FASTCUP |
+
+
+### FACEIT
+
+| Player(s) | Country | Team | Reason | Start | End |
+|---|---:|---|---|---:|---:|
+| WANGJ | CN | — | Cheating | 2025‑05‑27 | 2027‑05‑27 |
+| SJR | PE | loboarmy | Cheating | 2025‑05‑27 | 2027‑05‑27 |
+| aleph | US | backwhenever | Cheating | 2025‑05‑27 | 2027‑05‑27 |
+| AxEcHo | PL | illuminar | Cheating | 2025‑05‑27 | 2027‑05‑27 |
+| **dan1q** | KZ | rage.kz | Cheating | 2025‑05‑27 | **Permanent** |
+| SlooKy | BY | junga | Cheating | 2025‑05‑27 | 2027‑05‑27 |
+| arma | RU | — | Cheating | 2025‑05‑19 | 2027‑05‑19 |
+| 1vanG | RU | — | Cheating | 2025‑05‑19 | 2027‑05‑19 |
+| Linko | PT | — | Cheating | 2025‑05‑19 | 2027‑05‑19 |
+| biffy | RU | — | Cheating | 2025‑05‑19 | 2027‑05‑19 |
+| EaazyBoost | RU | — | Cheating | 2025‑05‑19 | 2027‑05‑19 |
+| keon | EE | GAMUZO eSports | Cheating | 2025‑05‑19 | 2027‑05‑19 |
+| OG_JOY | UA | — | Receiving an unfair advantage | 2025‑05‑19 | 2027‑05‑19 |
+| **pfq** | RU | kay team | Cheating | 2024‑11‑04 | **Permanent** |
+| ZEMO | PL | devils.one | Cheating | 2024‑11‑01 | 2026‑11‑01 |
+| WorldBreak3r, Yadd, V1, Esphirion, PRA | IL / UA / UA / UA / UA | shapito | Cheating | 2024‑10‑30 | 2026‑10‑30 |
+| rayenn, bitonzixi | IL / IL | — | Cheating | 2024‑10‑30 | 2026‑10‑30 |
+| mo5kow | RU | — | Cheating | 2024‑10‑30 | 2026‑10‑30 |
+| H0k17 | RU | — | Cheating | 2024‑10‑30 | 2026‑10‑30 |
+| fArT666 | RU | KamKom | Cheating | 2024‑03‑05 | 2026‑03‑05 |
+| Alexan1ch | RU | NAMELESS (EU mix) | Cheating | 2024‑03‑05 | 2026‑03‑05 |
+| zeins | UA | — | Cheating | 2024‑02‑29 | 2026‑02‑29 |
+| diis6 | DK | — | Cheating | 2024‑02‑26 | 2026‑02‑26 |
+| **EMIYA** | US | rocket | Cheating | 2024‑02‑19 | **Permanent** |
+| zLy | RU | — | Cheating | 2024‑02‑18 | 2026‑02‑18 |
+| lockstock | RU | — | Cheating | 2023‑11‑30 | 2025‑11‑30 |
+| r1cks | RU | ec kostroma | Cheating | 2023‑11‑30 | 2025‑11‑30 |
+| Cuizera | TR | tnt gaming | Cheating | 2023‑11‑30 | 2025‑11‑30 |
+
+---
+
+### Sources and Notes
+- FASTCUP / player cards.
+- FACEIT / public player pages.
+- Akros Anti-Cheat / public announcements.
+
+If additional publisher restrictions are in place for a specific discipline (for example, VAC), they apply **on top of** this list. If there are discrepancies between sources, the information from the “Priority decisions on the CCT case (2025‑10‑02)” section takes precedence.
+
+---
+
+## MySkill Banlist (Активные баны)
+
 ## Политика допуска
 Myskill оставляет за собой право отказать в участии игрокам, имеющим действующие баны от издателя игры или других киберспортивных организаций, турнирных операторов и античит систем, которые Myskill считает авторитетными. Если участник турнира получил (или получит) бан от античит-системы издателя (Valve Anti-Cheat) либо любой другой античит-системы, используемой на турнирной платформе (включая FaceIT AC, GameGuard, Akros), он подлежит дисквалификации задним числом, начиная с его первого матча.
 
@@ -10,20 +105,20 @@ Myskill оставляет за собой право отказать в уча
 
 ### Дисквалификация на 2 года (до 2027‑10‑02)
 - **Daniil “tEO” Prok (RU)** — Cheating — источники: CCT / Akros — [HLTV](https://www.hltv.org/player/22429/teo)
-- **Dastan “dosikk” Mauessov (KZ)** — Cheating — источники: CCT / Akros — [HLTV](https://www.hltv.org/player/24649/dosikk)  
-- **Mark “d0RREN” Karachevtsev (RU)** — Cheating — источники: CCT / Akros — [HLTV](https://www.hltv.org/player/23987/d0rren)  
-- **Idris “1Drezz” Beksultanov (KZ)** — Cheating — источники: CCT / Akros — [HLTV](https://www.hltv.org/player/24907/1drezz)  
+- **Dastan “dosikk” Mauessov (KZ)** — Cheating — источники: CCT / Akros — [HLTV](https://www.hltv.org/player/24649/dosikk)
+- **Mark “d0RREN” Karachevtsev (RU)** — Cheating — источники: CCT / Akros — [HLTV](https://www.hltv.org/player/23987/d0rren)
+- **Idris “1Drezz” Beksultanov (KZ)** — Cheating — источники: CCT / Akros — [HLTV](https://www.hltv.org/player/24907/1drezz)
 - **Nurmukhammed “singulier” Mugal (KZ)** — Cheating — источники: CCT / Akros — [HLTV](https://www.hltv.org/player/24202/singulier)
 - **Zhanibek “R3LiFwOw” Kuatov (KZ)** — Cheating — источники: CCT / Akros — [HLTV](https://www.hltv.org/player/23665/r3lifwow)
-- **Raiymbek “dune” Dusenov (KZ)** — Account Sharing — источник: CCT / Akros — [HLTV](https://www.hltv.org/player/24906/dune) 
+- **Raiymbek “dune” Dusenov (KZ)** — Account Sharing — источник: CCT / Akros — [HLTV](https://www.hltv.org/player/24906/dune)
 
 ### Дисквалификация на 6 месяцев (до 2026‑04‑02)
-- **ElayDzha (KZ)** — [HLTV](https://www.hltv.org/player/24501/elaydzha)  
-- **rinn (KZ)** — [HLTV](https://www.hltv.org/player/23318/rinn)  
-- **OxygeN (KZ)** — [HLTV](https://www.hltv.org/player/23316/oxygen)  
-- **for2na (KZ)** — [HLTV](https://www.hltv.org/player/23539/for2na)  
-- **ddoni (KZ)** — [HLTV](https://www.hltv.org/player/24646/ddoni)  
-- **tsukumeow (KZ)** — [HLTV](https://www.hltv.org/player/24650/tsukumeow)  
+- **ElayDzha (KZ)** — [HLTV](https://www.hltv.org/player/24501/elaydzha)
+- **rinn (KZ)** — [HLTV](https://www.hltv.org/player/23318/rinn)
+- **OxygeN (KZ)** — [HLTV](https://www.hltv.org/player/23316/oxygen)
+- **for2na (KZ)** — [HLTV](https://www.hltv.org/player/23539/for2na)
+- **ddoni (KZ)** — [HLTV](https://www.hltv.org/player/24646/ddoni)
+- **tsukumeow (KZ)** — [HLTV](https://www.hltv.org/player/24650/tsukumeow)
 - **krc (KR)** — [HLTV](https://www.hltv.org/player/23990/krc)
 
 ---


### PR DESCRIPTION
## Summary
- clarify the introductory note to mention the retained Russian original
- append the original Russian banlist content beneath the English translation to provide both language versions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfc85e73c8832294e3b8182bf9906a