### PR TITLE
Revamp README with enriched bilingual documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,34 @@
-## Navigation
+# 🏆 MySkill Tournament Operator
 
+Welcome to the official **MySkill Tournament Operator** repository.
+Here you will find **regulations, rules, and official information** that govern MySkill tournaments and leagues.
+
+> 🇷🇺 На русском ниже — пролистайте до раздела [«Русская версия»](#-русская-версия).
+
+---
+
+## 📋 Table of Contents
+- [Repository Snapshot](#-repository-snapshot)
+- [Navigation](#-navigation)
+- [How to Use the Documents](#-how-to-use-the-documents)
+- [Repository Structure](#-repository-structure)
+- [Contribution Guidelines](#-contribution-guidelines)
+- [Contacts](#-contacts)
+- [Русская версия](#-русская-версия)
+
+---
+
+## 📂 Repository Snapshot
+- 📜 **Tournament Regulations** – official documents with competition rules.
+- ⚖️ **Participation Rules** – eligibility criteria and obligations for players and teams.
+- 🛠️ **Technical Standards** – server infrastructure, anti-cheat policies, and gameplay settings.
+- 📑 **Supporting Documentation** – offline/online procedures, legal notices, and auxiliary materials.
+
+These files are continuously updated to reflect the latest requirements for MySkill events, ensuring that everyone has access to the single source of truth.
+
+---
+
+## 🧭 Navigation
 - [Banlist](banlist/banlist.md)
 - Rules
   - [General Rulebook](rules/general/general_rulebook.md)
@@ -8,8 +37,71 @@
 - Tournaments
   - [Female Pro League #1 (2025)](tournaments/2025/Female%20Pro%20League%20%231.md)
 
-## Навигация
+> ℹ️ Looking for a specific regulation? Use the search function in your viewer or clone the repository and rely on IDE/project search to find keywords across all documents.
 
+---
+
+## 📘 How to Use the Documents
+1. **Stay Updated** – always rely on the latest commit in this repository before a tournament starts.
+2. **Share with Teams** – point players, managers, and partners to the relevant files instead of distributing separate copies.
+3. **Track Revisions** – use Git history to review amendments and confirm when rules have changed.
+4. **Reference in Disputes** – cite the exact file and section to ensure consistent interpretation during appeals.
+
+---
+
+## 🗂️ Repository Structure
+```
+./
+├── banlist/              # Player and team restrictions
+├── rules/
+│   └── general/          # Core regulations, in-game policies, roster management
+└── tournaments/
+    └── 2025/             # Event-specific regulations (year-based)
+```
+
+---
+
+## 🤝 Contribution Guidelines
+- ✅ **Internal Staff**: update documents through pull requests, referencing the changes and reasons in the PR description.
+- 🛡️ **External Requests**: submit suggestions via email; unauthorized direct edits are not permitted.
+- 📝 **Versioning**: include date stamps inside documents when major updates occur.
+
+---
+
+## 📌 Contacts
+For questions, clarifications, or requests:
+- 📧 info@myskill.kz
+
+⚠️ All materials published in this repository are official MySkill documents. Any copying or use is allowed only with the written consent of the organizers.
+
+---
+
+## 🇷🇺 Русская версия
+
+Добро пожаловать в официальный репозиторий **MySkill Tournament Operator**.
+Здесь собраны **регламенты, правила и официальная информация**, относящиеся к турнирам и лигам MySkill.
+
+---
+
+### 📋 Содержание
+- [Что внутри](#-что-внутри)
+- [Навигация](#-навигация)
+- [Как работать с документами](#-как-работать-с-документами)
+- [Структура репозитория](#-структура-репозитория)
+- [Обновления и вклад](#-обновления-и-вклад)
+- [Контакты](#-контакты)
+
+---
+
+### 📂 Что внутри
+- 📜 **Регламенты турниров** – официальные документы с правилами проведения соревнований.
+- ⚖️ **Правила участия** – требования и обязанности игроков и команд.
+- 🛠️ **Технические стандарты** – серверная инфраструктура, политика античита и игровые настройки.
+- 📑 **Вспомогательные материалы** – оффлайн/онлайн протоколы, юридическая информация и служебные шаблоны.
+
+---
+
+### 🧭 Навигация
 - [Банлист](banlist/banlist.md)
 - Правила
   - [Общий регламент](rules/general/general_rulebook.md)
@@ -17,3 +109,42 @@
   - [Правила составов](rules/general/roster_rules.md)
 - Турниры
   - [Female Pro League #1 (2025)](tournaments/2025/Female%20Pro%20League%20%231.md)
+
+> ℹ️ Используйте поиск по репозиторию, чтобы быстро находить нужные разделы и пункты.
+
+---
+
+### 📘 Как работать с документами
+1. **Следите за актуальностью** – перед турниром сверяйтесь с последней версией файлов.
+2. **Делитесь ссылками** – отправляйте партнёрам и игрокам прямые ссылки на документы вместо отдельных копий.
+3. **Отслеживайте историю** – используйте историю Git для проверки, когда и какие изменения были внесены.
+4. **Ссылайтесь в спорах** – указывайте точный файл и пункт, чтобы обеспечить единое понимание правил.
+
+---
+
+### 🗂️ Структура репозитория
+```
+./
+├── banlist/              # Ограничения на игроков и команды
+├── rules/
+│   └── general/          # Базовые регламенты, внутриигровые правила, управление составами
+└── tournaments/
+    └── 2025/             # Регламенты турниров, сгруппированных по годам
+```
+
+---
+
+### 🔄 Обновления и вклад
+- ✅ **Команда MySkill**: вносите изменения через pull request с описанием причин и основных правок.
+- 🛡️ **Внешние предложения**: направляйте предложения на почту; прямые правки без согласования запрещены.
+- 📝 **Версионность**: при крупных правках указывайте дату обновления внутри самого документа.
+
+---
+
+### 📌 Контакты
+По вопросам и предложениям:
+- 📧 info@myskill.kz
+
+⚠️ Все материалы, опубликованные в этом репозитории, являются официальными документами MySkill. Любое копирование или использование допускается только с письменного согласия организаторов.
+
+---


### PR DESCRIPTION
## Summary
- expand the README with styled English and Russian introductions, navigation, and usage guidance
- add repository structure, contribution notes, and contact information for both language sections

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68dfc92862208322bcaf5bc424978b14