### PR TITLE
Add announcement: K27 Esports and Virtus.pro withdraw from tournament

### DIFF
--- a/announcements/2026/k27_esports_virtus_pro_withdrawals.md
+++ b/announcements/2026/k27_esports_virtus_pro_withdrawals.md
@@ -1,0 +1,59 @@
+🟣 **Официальное обновление — K27 Esports и Virtus.pro снялись с турнира**
+
+Команды **K27 Esports** и **Virtus.pro** снялись с турнира.
+
+Ниже зафиксирован обновлённый посев команд и список следующих слотов после изменений.
+
+🧾 **Обновлённый посев**
+
+1. **WW TEAM** — VRS №66 — **1172 pts**
+2. **The Huns Esports** — VRS №70 — **1159 pts**
+3. **DEPO** — VRS №114 — **1015 pts**
+4. **CYBERSHOKE Prospects** — VRS №117 — **994 pts**
+5. **Team OMEGA** — VRS №121 — **987 pts**
+6. **Rune Eaters** — VRS №133 — **934 pts**
+7. **team NOVAQ** — VRS №138 — **913 pts**
+8. **A Great Chaos** — VRS №243 — **668 pts**
+
+🧩 **Следующие слоты**
+
+9. **Dark Moon** — VRS №253 — **651 pts**
+10. **WRAITH PCIFIC** — HLTV №162 — **5 pts**
+11. **Game Point** — HLTV №224 — **2 pts**
+12. **Tricksters** — HLTV №231 — **1 pts**
+13. **THE UNIT** — HLTV №234 — **1 pts**
+14. **TroubleMakers** — **5 HLTV Profiles**
+15. **turan** — **4 HLTV Profiles**
+16. **ALTAY** — **3 HLTV Profiles**
+17. **666** — **2 HLTV Profiles**
+
+---
+
+🟣 **Official Update — K27 Esports and Virtus.pro Withdraw from the Tournament**
+
+**K27 Esports** and **Virtus.pro** have withdrawn from the tournament.
+
+The updated team seeding and the next available slots after the changes are listed below.
+
+🧾 **Updated seeding**
+
+1. **WW TEAM** — VRS №66 — **1172 pts**
+2. **The Huns Esports** — VRS №70 — **1159 pts**
+3. **DEPO** — VRS №114 — **1015 pts**
+4. **CYBERSHOKE Prospects** — VRS №117 — **994 pts**
+5. **Team OMEGA** — VRS №121 — **987 pts**
+6. **Rune Eaters** — VRS №133 — **934 pts**
+7. **team NOVAQ** — VRS №138 — **913 pts**
+8. **A Great Chaos** — VRS №243 — **668 pts**
+
+🧩 **Next slots**
+
+9. **Dark Moon** — VRS №253 — **651 pts**
+10. **WRAITH PCIFIC** — HLTV №162 — **5 pts**
+11. **Game Point** — HLTV №224 — **2 pts**
+12. **Tricksters** — HLTV №231 — **1 pts**
+13. **THE UNIT** — HLTV №234 — **1 pts**
+14. **TroubleMakers** — **5 HLTV Profiles**
+15. **turan** — **4 HLTV Profiles**
+16. **ALTAY** — **3 HLTV Profiles**
+17. **666** — **2 HLTV Profiles**


### PR DESCRIPTION
### Motivation

- Provide an official announcement that **K27 Esports** and **Virtus.pro** have withdrawn from the tournament and show the updated seeding and next-available slots in both Russian and English.

### Description

- Add new announcement file `announcements/2026/k27_esports_virtus_pro_withdrawals.md` containing bilingual (Russian and English) messaging with updated seeding and next slots lists.
- Include formatted team seed positions, points, and the next slot entries for clarity and publication.
- Use consistent sectioning, emojis, and list formatting to match other announcement styles.

### Testing

- No automated tests were run for this content-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27146e6ee08322bf0c451f6d0e6239)